### PR TITLE
Use raw GitHub links for userscript

### DIFF
--- a/deadname-remover.user.js
+++ b/deadname-remover.user.js
@@ -1,17 +1,17 @@
 // ==UserScript==
 // @name         Deadname-Remover
 // @version      1.1.2
-// @description  Replace dead names with preffered names.
-// @author       William Hayward
+// @description  Replace dead names with preferred names.
+// @author       William Hayward & Ari Gibson
 // @license      MIT
 // @match        *://*/*
 // @grant        none
 // @run-at       document-start
-// @namespace    https://github.com/WillHayCode/Deadname-Remover
-// @supportURL   https://github.com/WillHayCode/Deadname-Remover/issues
-// @require      https://github.com/WillHayCode/Deadname-Remover/raw/master/deadname-remover.require.js
-// @updateURL    https://github.com/WillHayCode/Deadname-Remover/raw/master/deadname-remover.meta.js
-// @downloadURL  https://github.com/WillHayCode/Deadname-Remover/raw/master/deadname-remover.user.js
+// @namespace    https://github.com/arimgibson/Deadname-Remover
+// @supportURL   https://github.com/arimgibson/Deadname-Remover/issues
+// @require      https://github.com/arimgibson/Deadname-Remover/raw/master/deadname-remover.require.js
+// @updateURL    https://github.com/arimgibson/Deadname-Remover/raw/master/deadname-remover.meta.js
+// @downloadURL  https://github.com/arimgibson/Deadname-Remover/raw/master/deadname-remover.user.js
 // ==/UserScript==
 
 (function() {

--- a/deadname-remover.user.js
+++ b/deadname-remover.user.js
@@ -9,9 +9,9 @@
 // @run-at       document-start
 // @namespace    https://github.com/WillHayCode/Deadname-Remover
 // @supportURL   https://github.com/WillHayCode/Deadname-Remover/issues
-// @require      https://github.com/WillHayCode/Deadname-Remover/blob/master/deadname-remover.require.js
-// @updateURL    https://github.com/WillHayCode/Deadname-Remover/blob/master/deadname-remover.meta.js
-// @downloadURL  https://github.com/WillHayCode/Deadname-Remover/blob/master/deadname-remover.user.js
+// @require      https://github.com/WillHayCode/Deadname-Remover/raw/master/deadname-remover.require.js
+// @updateURL    https://github.com/WillHayCode/Deadname-Remover/raw/master/deadname-remover.meta.js
+// @downloadURL  https://github.com/WillHayCode/Deadname-Remover/raw/master/deadname-remover.user.js
 // ==/UserScript==
 
 (function() {


### PR DESCRIPTION
Using /blob/ links displays GitHub's UI, thus causing Tampermonkey to try downloading and including HTML rather than the JS code.