### PR TITLE
Fix options page appearing on browser update

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -8,8 +8,10 @@ loadSettings().then(($setting) => {
     }
 });
 
-chrome.runtime.onInstalled.addListener(() => {
-    chrome.runtime.openOptionsPage();
+chrome.runtime.onInstalled.addListener((e) => {
+    if(e.reason === "installed") {
+        chrome.runtime.openOptionsPage();
+    }
 });
 
 interface PortInfo {


### PR DESCRIPTION
Fixes #35.

[`chrome.runtime.onInstalled`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onInstalled) is called [for reasons other than just the extension being installed](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/OnInstalledReason).

This PR adds a check only for the `install` reason.