### PR TITLE
prevent nesting `mark` tags

### DIFF
--- a/src/inject/inject.ts
+++ b/src/inject/inject.ts
@@ -105,7 +105,7 @@ function replaceText(text: string, isTitle?: boolean) {
         if (revert) {
             oldWords = oldWords.map(text => `<mark replaced="">${text}</mark>`);
         } else {
-            newWords = newWords.map(text => `<mark replaced="">${text}</mark>`);
+            newWords = newWords.map(text => text.includes("replaced") ? text : `<mark replaced="">${text}</mark>`);
         }
     }
     const oldTextsLen = oldWords.map(word => word.length);


### PR DESCRIPTION
Previously, the highlight setting would repeatedly nest tags
![image](https://user-images.githubusercontent.com/43897385/208400728-d5c9e156-e382-4907-97f4-8e62cf5b1c59.png)
This prevents that from happening by not surrounding already tagged text with more tags