### PR TITLE
Fix deadname being logged to browser console

### DIFF
--- a/entrypoints/background/utils.ts
+++ b/entrypoints/background/utils.ts
@@ -22,6 +22,12 @@ export async function handleUpdate(details: Runtime.OnInstalledDetailsType) {
 
   let config = await getConfig()
 
+  // Ensure the specific value is set to false if undefined
+  if (config.hideDebugInfo === undefined) {
+    config.hideDebugInfo = false
+    await setConfig(config)
+  }
+
   // If last version is less than 2.0.0, open the options page with the upgrade flag
   if (details.previousVersion && compare(details.previousVersion, '2.0.0', '<')) {
     // If stealth mode is disabled, open the options page with the upgrade flag

--- a/entrypoints/background/utils.ts
+++ b/entrypoints/background/utils.ts
@@ -22,10 +22,14 @@ export async function handleUpdate(details: Runtime.OnInstalledDetailsType) {
 
   let config = await getConfig()
 
-  // Ensure the specific value is set to false if undefined
+  // Ensure hideDebugInfo is initialized
   if (config.hideDebugInfo === undefined) {
     config.hideDebugInfo = false
-    await setConfig(config)
+    try {
+      await setConfig(config)
+    } catch (error) {
+      errorLog('error setting hideDebugInfo config', error)
+    }
   }
 
   // If last version is less than 2.0.0, open the options page with the upgrade flag

--- a/services/configService.ts
+++ b/services/configService.ts
@@ -12,6 +12,7 @@ export const defaultSettings: UserSettings = {
   enabled: true,
   blockContentBeforeDone: true,
   stealthMode: false,
+  hideDebugInfo: false,
   highlightReplacedNames: true,
   syncSettingsAcrossDevices: false,
   theme: 'trans',

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -26,6 +26,12 @@ export const generalSettingKeys = [
       'Hide gender-related elements to protect privacy and accidentally being outed. Disables text highlighting, replaces the extension icon, and hides the popup options when the extension\'s icon is clicked.',
   },
   {
+    label: 'Hide Debug Info',
+    value: 'hideDebugInfo',
+    description:
+      'Hide debug information from the console. This can help protect your privacy by not exposing potentially sensitive information.',
+  },
+  {
     label: 'Block Page Until Replacements Finished',
     value: 'blockContentBeforeDone',
     description:

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -29,7 +29,7 @@ export const generalSettingKeys = [
     label: 'Hide Debug Info',
     value: 'hideDebugInfo',
     description:
-      'Hide debug information from the console. This can help protect your privacy by not exposing potentially sensitive information.',
+      'Hide debug information from the browser console. This can help protect your privacy by not exposing potentially sensitive information.',
   },
   {
     label: 'Block Page Until Replacements Finished',

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -5,7 +5,7 @@ import { getConfig } from '@/services/configService'
 export async function debugLog(message: string, ...data: unknown[]) {
   const { hideDebugInfo } = await getConfig()
   if (hideDebugInfo) return
-  
+
   console.debug(`Deadname Remover: ${message}`, ...data)
 }
 

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,7 +1,11 @@
 import type { Difference } from 'microdiff'
 import { Names } from './types'
+import { getConfig } from '@/services/configService'
 
-export function debugLog(message: string, ...data: unknown[]) {
+export async function debugLog(message: string, ...data: unknown[]) {
+  const { hideDebugInfo } = await getConfig()
+  if (hideDebugInfo) return
+  
   console.debug(`Deadname Remover: ${message}`, ...data)
 }
 

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -48,6 +48,7 @@ export const UserSettings = v.object({
   ),
   enabled: v.boolean(),
   stealthMode: v.boolean(),
+  hideDebugInfo: v.boolean(),
   blockContentBeforeDone: v.boolean(),
   highlightReplacedNames: v.boolean(),
   syncSettingsAcrossDevices: v.boolean(),


### PR DESCRIPTION
Fixes #592

This pull request introduces a new feature to hide debug information in the console for enhanced privacy. The main changes include adding a new setting `hideDebugInfo` to the user settings and updating related configurations and functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option that lets you control the visibility of debug messages, enhancing your privacy by suppressing potentially sensitive log output.
  - With this option enabled, debug messages now respect your settings, resulting in a cleaner console and a more streamlined user experience.
  - Added a new property "Hide Debug Info" to user settings for better privacy control.
  - Conditional checks in the system ensure that debug information is only logged when appropriate settings are configured.
  - Improved error handling during configuration updates to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->