### PR TITLE
Customizable Keyboard Shortcut to Enable/Disable

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If you'd like to submit a bug or request a feature but don't want to sign up for
 
 See an updated project roadmap on this project's [GitHub Projects](https://github.com/arimgibson/Deadname-Remover/projects). At a high level, these are features that are planned for the extension:
 1. Global and per-site blocklists
-2. Customizable keybinding to toggle the extension`
+2. Customizable keybinding to toggle the extension (in testing)
 3. Publishing to the Edge Add-ons store
 4. Custom regex patterns for advanced name replacement (including titles, suffixes, salutations, etc.)
 

--- a/entrypoints/options/App.svelte
+++ b/entrypoints/options/App.svelte
@@ -431,7 +431,7 @@
           </div>
 
           <div>
-            <label for="keyboard-shortcut" class="text-gray-700 text-base">Toggle Extension Shortcut</label>
+            <label for="keyboard-shortcut" class="text-gray-700 text-base">Enable/Disable Extension Keyboard Shortcut</label>
             <div class="mt-2">
               <div
                 id="keyboard-shortcut"
@@ -481,8 +481,8 @@
               </div>
             </div>
             <p class="text-sm text-gray-500 mt-2">
-              <strong>Note: it is recommended to ensure the key combination used is not already in use by another browser feature or extension.</strong>
-              <br /><br />
+              <strong class="mb-4 inline-block">Note: it is recommended to ensure the key combination used is not already in use by another browser feature or extension.</strong>
+              <br />
               Keyboard shortcut to quickly enable or disable the extension. Does not show any indication of being toggled for privacy purposes.
             </p>
           </div>

--- a/entrypoints/options/App.svelte
+++ b/entrypoints/options/App.svelte
@@ -63,6 +63,8 @@
   let showFaqModal = $state(false)
   let showFaqTooltip = $state(false)
 
+  let captureShortcut = $state(false)
+
   const faqs = [
     {
       question: 'How do I add multiple names?',
@@ -281,6 +283,27 @@
       })
     }
   }
+
+  function formatKeyboardShortcut(shortcut: UserSettings['toggleKeybinding']): string | null {
+    if (!shortcut) return null
+
+    const parts: string[] = []
+
+    if (shortcut.ctrl) parts.push('Ctrl')
+    if (shortcut.alt) parts.push('Alt')
+    if (shortcut.shift) parts.push('Shift')
+    if (shortcut.meta) parts.push('Meta')
+
+    // Format key nicely
+    let key = shortcut.key
+    if (key === ' ') key = 'Space'
+    else if (key.length === 1) key = key.toUpperCase()
+    else if (key === 'Escape') key = 'Esc'
+
+    parts.push(key)
+
+    return parts.join(' + ')
+  }
 </script>
 
 <Toaster />
@@ -424,6 +447,63 @@
             </div>
             <p class="text-sm text-gray-500 mt-2">
               Changes the color of the highlight on replaced names.
+            </p>
+          </div>
+
+          <div>
+            <label for="keyboard-shortcut" class="text-gray-700 text-base">Toggle Extension Shortcut</label>
+            <div class="mt-2">
+              <div
+                id="keyboard-shortcut"
+                class="input border rounded flex items-center justify-between p-2 cursor-pointer"
+                tabindex="0"
+                role="button"
+                aria-label="Press keys to set shortcut"
+                onclick={() => captureShortcut = true}
+                onkeydown={(e) => {
+                  if (captureShortcut) {
+                    e.preventDefault()
+
+                    // Skip if only modifier keys are pressed
+                    const isModifierKey = ['Control', 'Alt', 'Shift', 'Meta'].includes(e.key)
+                    if (!isModifierKey) {
+                      settings.toggleKeybinding = {
+                        key: e.key,
+                        alt: e.altKey,
+                        ctrl: e.ctrlKey,
+                        shift: e.shiftKey,
+                        meta: e.metaKey,
+                      }
+                      captureShortcut = false
+                    }
+                  }
+                }}
+                onblur={() => captureShortcut = false}
+              >
+                <span class={captureShortcut ? 'text-theme-500' : 'text-gray-700'}>
+                  {captureShortcut
+                    ? 'Press keys...'
+                    : settings.toggleKeybinding
+                      ? formatKeyboardShortcut(settings.toggleKeybinding)
+                      : 'Disabled -- Click Here to Set'}
+                </span>
+                <button
+                  type="button"
+                  class="text-gray-500 hover:text-gray-700"
+                  onclick={(e) => {
+                    e.stopPropagation()
+                    settings.toggleKeybinding = defaultSettings.toggleKeybinding
+                  }}
+                  aria-label="Reset to default shortcut"
+                >
+                  <i class="i-material-symbols:refresh text-lg" aria-hidden="true"></i>
+                </button>
+              </div>
+            </div>
+            <p class="text-sm text-gray-500 mt-2">
+              <strong>Note: it is recommended to ensure the key combination used is not already in use by another browser feature or extension.</strong>
+              <br /><br />
+              Keyboard shortcut to quickly enable or disable the extension. Does not show any indication of being toggled for privacy purposes.
             </p>
           </div>
         </div>

--- a/entrypoints/options/App.svelte
+++ b/entrypoints/options/App.svelte
@@ -22,6 +22,7 @@
   } from '@/services/configService'
   import {
     filterEmptyArraysFromDiff,
+    formatKeyboardShortcut,
     debugLog,
     errorLog,
   } from '@/utils'
@@ -282,27 +283,6 @@
         className: 'h-12 text-lg',
       })
     }
-  }
-
-  function formatKeyboardShortcut(shortcut: UserSettings['toggleKeybinding']): string | null {
-    if (!shortcut) return null
-
-    const parts: string[] = []
-
-    if (shortcut.ctrl) parts.push('Ctrl')
-    if (shortcut.alt) parts.push('Alt')
-    if (shortcut.shift) parts.push('Shift')
-    if (shortcut.meta) parts.push('Meta')
-
-    // Format key nicely
-    let key = shortcut.key
-    if (key === ' ') key = 'Space'
-    else if (key.length === 1) key = key.toUpperCase()
-    else if (key === 'Escape') key = 'Esc'
-
-    parts.push(key)
-
-    return parts.join(' + ')
   }
 </script>
 

--- a/entrypoints/popup/App.svelte
+++ b/entrypoints/popup/App.svelte
@@ -7,7 +7,7 @@
     setupConfigListener,
   } from '@/services/configService'
   import { checkForStealthUpgradeNotification, clearStealthUpgradeNotification } from '@/utils/migrations'
-  import { errorLog } from '@/utils'
+  import { errorLog, formatKeyboardShortcut } from '@/utils'
   import type { UserSettings } from '@/utils/types'
   import { themes } from '@/utils/types'
   import { generalSettingKeys } from '@/utils/constants'
@@ -154,6 +154,13 @@
                 class="i-material-symbols:arrow-drop-down text-xl absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none"
               ></i>
             </div>
+          </div>
+
+          <div class="flex justify-between items-center h-8 mt-3">
+            <span class="text-gray-700 text-base">Enable/Disable Shortcut</span>
+            <span class="text-sm text-gray-600 bg-gray-100 px-2 py-1 rounded">
+              {settings.toggleKeybinding ? formatKeyboardShortcut(settings.toggleKeybinding) : 'Disabled'}
+            </span>
           </div>
         </div>
       </section>

--- a/services/configService.ts
+++ b/services/configService.ts
@@ -15,6 +15,7 @@ export const defaultSettings: UserSettings = {
   highlightReplacedNames: true,
   syncSettingsAcrossDevices: false,
   theme: 'trans',
+  toggleKeybinding: null,
 }
 
 export async function getConfig(): Promise<UserSettings> {

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,5 +1,5 @@
 import type { Difference } from 'microdiff'
-import { Names } from './types'
+import { Names, UserSettings } from './types'
 
 export function debugLog(message: string, ...data: unknown[]) {
   console.debug(`Deadname Remover: ${message}`, ...data)
@@ -56,4 +56,31 @@ export function haveNamesChanged(previous: Names | undefined, current: Names): b
 
 export function kebabToCamel(str: string): string {
   return str.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase())
+}
+
+/**
+ * Formats a keyboard shortcut object into a human-readable string.
+ *
+ * @param shortcut - The shortcut object to format.
+ * @returns A string representation of the shortcut, or null if the shortcut is undefined.
+ */
+export function formatKeyboardShortcut(shortcut: UserSettings['toggleKeybinding']): string | null {
+  if (!shortcut) return null
+
+  const parts: string[] = []
+
+  if (shortcut.ctrl) parts.push('Ctrl')
+  if (shortcut.alt) parts.push('Alt')
+  if (shortcut.shift) parts.push('Shift')
+  if (shortcut.meta) parts.push('Meta')
+
+  // Format key nicely
+  let key = shortcut.key
+  if (key === ' ') key = 'Space'
+  else if (key.length === 1) key = key.toUpperCase()
+  else if (key === 'Escape') key = 'Esc'
+
+  parts.push(key)
+
+  return parts.join(' + ')
 }

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -35,6 +35,14 @@ export const themes = [{
   value: 'high-contrast',
 }] as const
 
+export const ToggleKeybinding = v.object({
+  key: v.string(),
+  alt: v.boolean(),
+  ctrl: v.boolean(),
+  shift: v.boolean(),
+  meta: v.boolean(),
+})
+
 export const UserSettings = v.object({
   names: v.pipe(
     v.object({
@@ -52,6 +60,7 @@ export const UserSettings = v.object({
   highlightReplacedNames: v.boolean(),
   syncSettingsAcrossDevices: v.boolean(),
   theme: v.union(themes.map(x => v.literal(x.value))),
+  toggleKeybinding: v.union([v.null(), ToggleKeybinding]),
 })
 
 export type UserSettings = v.InferOutput<typeof UserSettings>


### PR DESCRIPTION
Pending some additional testing and feedback from users before going live to all users.

- Add new setting for keyboard shortcut
- Update options UI to allow adding a keyboard shortcut
- Update popup UI to display what the keyboard shortcut is
- Update content script to register listener for user-defined keyboard shortcut

Closes #570 and closes #318 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enabled a customizable keyboard shortcut that lets you toggle the extension via an interactive UI, with options to capture, display, and reset the keybinding.

- **Documentation**
  - Updated the roadmap description to indicate that the keyboard shortcut feature is currently in testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->