### PR TITLE
Exclude SVGs from Processing

### DIFF
--- a/services/textProcessor.ts
+++ b/services/textProcessor.ts
@@ -364,6 +364,7 @@ export class TextProcessor {
       || element.tagName.toLowerCase() === 'style'
       || element.tagName.toLowerCase() === 'noscript'
       || element.tagName.toLowerCase() === 'template'
+      || element.tagName.toLowerCase() === 'svg'
     )
   }
 


### PR DESCRIPTION
Should help with performance; these shouldn't have to be processed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved text handling by excluding non-text graphical elements, ensuring more consistent and reliable text display throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->