### PR TITLE
Move `Hide Debug Info` to Advanced Settings, Add `Default Allow All Sites` to Popup Settings

### DIFF
--- a/entrypoints/options/App.svelte
+++ b/entrypoints/options/App.svelte
@@ -28,7 +28,7 @@
   } from '@/utils'
   import type { UserSettings } from '@/utils/types'
   import { themes } from '@/utils/types'
-  import { generalSettingKeys } from '@/utils/constants'
+  import { generalSettingKeys, siteFilteringSettingKeys } from '@/utils/constants'
   import toast, { Toaster } from 'svelte-french-toast'
   import 'text-security/text-security-disc.css'
   import diff from 'microdiff'
@@ -471,30 +471,32 @@
           Site Filtering
         </h2>
         <div class="space-y-6">
-          <div>
-            <label
-              for="default-allow-toggle"
-              class="flex justify-between items-center text-gray-700 text-base"
-            >
-              Default Allow
-              <div class="accessible-switch switch-theme-400">
-                <input
-                  type="checkbox"
-                  id="default-allow-toggle"
-                  class="peer"
-                  bind:checked={settings.defaultAllowMode}
-                  aria-describedby="default-allow-description"
-                />
-                <span class="switch-dot" role="presentation"></span>
-              </div>
-            </label>
-            <p
-              id="default-allow-description"
-              class="text-sm text-gray-500 mt-2"
-            >
-              When enabled, the extension will replace names on all sites by default, except those in the blocklist. When disabled, it will only replace names on sites in the allowlist.
-            </p>
-          </div>
+          {#each siteFilteringSettingKeys as setting (setting.value)}
+            <div>
+              <label
+                for={setting.value}
+                class="flex justify-between items-center text-gray-700 text-base"
+              >
+                {setting.label}
+                <div class="accessible-switch switch-theme-400">
+                  <input
+                    type="checkbox"
+                    id={setting.value}
+                    class="peer"
+                    bind:checked={settings[setting.value]}
+                    aria-describedby={`${setting.value}-description`}
+                  />
+                  <span class="switch-dot" role="presentation"></span>
+                </div>
+              </label>
+              <p
+                id={`${setting.value}-description`}
+                class="text-sm text-gray-500 mt-2"
+              >
+                {setting.description}
+              </p>
+            </div>
+          {/each}
           <TagInput
             bind:this={allowlistTagInput}
             type="domain"

--- a/entrypoints/options/App.svelte
+++ b/entrypoints/options/App.svelte
@@ -48,6 +48,9 @@
   let firstSettingsLoaded = $state(false)
   let previousStealthMode = false
 
+  const regularSettings = generalSettingKeys.filter(setting => !setting.advanced)
+  const advancedSettings = generalSettingKeys.filter(setting => setting.advanced)
+
   let hideDeadnames = $state(true)
 
   let unsavedChanges = $derived.by(() => {
@@ -266,7 +269,7 @@
           role="group"
           aria-labelledby="general-settings-heading"
         >
-          {#each generalSettingKeys as setting (setting.value)}
+          {#each regularSettings as setting (setting.value)}
             <div>
               <label
                 for={setting.value}
@@ -511,6 +514,48 @@
             onUpdate={(newTags: string[]) => settings.blocklist = newTags}
           />
         </div>
+      </section>
+
+      <!-- Advanced Settings -->
+      <section class="mb-8" aria-labelledby="advanced-settings-heading">
+        <details class="group">
+          <summary class="flex items-center gap-2 mb-4 cursor-pointer">
+            <h2
+              id="advanced-settings-heading"
+              class="text-xl font-medium text-gray-700"
+            >
+              Advanced Settings
+            </h2>
+            <i class="i-material-symbols:expand-more text-lg transition-transform duration-200 group-open:-rotate-180" aria-hidden="true"></i>
+        </summary>
+        <div class="space-y-6">
+          {#each advancedSettings as setting (setting.value)}
+            <div>
+              <label
+                for={setting.value}
+                class="flex justify-between items-center text-gray-700 text-base"
+                >{setting.label}
+                <div class="accessible-switch switch-theme-400">
+                  <input
+                    type="checkbox"
+                    id={setting.value}
+                    class="peer"
+                    bind:checked={settings[setting.value]}
+                    aria-describedby={`${setting.value}-description`}
+                  />
+                  <span class="switch-dot" role="presentation"></span>
+                </div>
+              </label>
+              <p
+                id={`${setting.value}-description`}
+                class="text-sm text-gray-500 mt-2"
+              >
+                {setting.description}
+              </p>
+            </div>
+          {/each}
+          </div>
+        </details>
       </section>
 
       <!-- Save Button -->

--- a/entrypoints/popup/App.svelte
+++ b/entrypoints/popup/App.svelte
@@ -10,7 +10,7 @@
   import { errorLog, formatKeyboardShortcut, registerKeyboardShortcut } from '@/utils'
   import type { UserSettings } from '@/utils/types'
   import { themes } from '@/utils/types'
-  import { generalSettingKeys } from '@/utils/constants'
+  import { generalSettingKeys, siteFilteringSettingKeys } from '@/utils/constants'
   import toast, { Toaster } from 'svelte-french-toast'
   import StealthMode from '@/components/StealthMode.svelte'
   import WarningIcon from '@/components/WarningIcon.svelte'
@@ -27,6 +27,12 @@
   let keyboardListener: ((event: KeyboardEvent) => void) | null = null
   let parsingStatus = $state<ParsingStatus | null>(null)
   let showMatchDetails = $state(false)
+
+  const regularSettings = generalSettingKeys.filter(setting => !setting.advanced)
+  const settingsToShow = [
+    ...regularSettings,
+    ...siteFilteringSettingKeys,
+  ]
 
   onMount(() => {
     // Use a non-async function for onMount that returns the cleanup directly
@@ -223,7 +229,7 @@
       <!-- General Settings -->
       <section class="mb-4" aria-labelledby="general-settings-heading">
         <div class="space-y-3" role="group">
-          {#each generalSettingKeys as setting (setting.value)}
+          {#each settingsToShow as setting (setting.value)}
             <label
               for={setting.value}
               class="flex justify-between items-center text-gray-700 text-sm"

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -21,34 +21,40 @@ export const generalSettingKeys = [
   {
     label: 'Enable Extension',
     value: 'enabled',
+    advanced: false,
     description: 'Enable or disable the extension\'s name replacement functionality.',
   },
   {
     label: 'Stealth Mode',
     value: 'stealthMode',
+    advanced: false,
     description:
       'Hide gender-related elements to protect privacy and accidentally being outed. Replaces the extension icon, and hides the popup options when the extension\'s icon is clicked. Recommended to disable text highlighting as well.',
   },
   {
     label: 'Hide Debug Info',
     value: 'hideDebugInfo',
+    advanced: true,
     description:
       'Hide debug information from the browser console. This can help protect your privacy by not exposing potentially sensitive information.',
   },
   {
     label: 'Block Page Until Replacements Finished',
     value: 'blockContentBeforeDone',
+    advanced: false,
     description:
       'Block the page until all replacements are finished to avoid displaying a deadname before replacement. Can cause slowdowns on lower-end devices.',
   },
   {
     label: 'Highlight Replaced Names',
     value: 'highlightReplacedNames',
+    advanced: false,
     description: 'Highlight replaced names to make them easier to spot.',
   },
   {
     label: 'Sync Settings Across Devices',
     value: 'syncSettingsAcrossDevices',
+    advanced: false,
     description: 'Sync settings across devices signed into the same browser profile (e.g. Google account).',
   },
 ] as const

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,3 +1,5 @@
+import type { SettingsKey } from '@/utils/types'
+
 export const nameKeys = [
   {
     label: 'First Names',
@@ -57,7 +59,16 @@ export const generalSettingKeys = [
     advanced: false,
     description: 'Sync settings across devices signed into the same browser profile (e.g. Google account).',
   },
-] as const
+] as const satisfies SettingsKey[]
+
+export const siteFilteringSettingKeys = [
+  {
+    label: 'Default Allow All Sites',
+    value: 'defaultAllowMode',
+    advanced: false,
+    description: 'When enabled, the extension will replace names on all sites by default, except those in the blocklist. When disabled, it will only replace names on sites in the allowlist.',
+  },
+] as const satisfies SettingsKey[]
 
 export const themeKeys = [
   {

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -44,6 +44,13 @@ export const themes = [{
   value: 'high-contrast',
 }] as const
 
+export interface SettingsKey {
+  label: string
+  value: string
+  advanced: boolean
+  description: string
+}
+
 export const ToggleKeybinding = v.object({
   key: v.string(),
   alt: v.boolean(),


### PR DESCRIPTION
- Mark all settings as advanced boolean, showing advanced settings under a drop down at the bottom of the settings
- Move `siteFilteringSettings` to const, dynamically render with `#each`
- Add `siteFilteringSettings` to popup settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings interface now organizes options into Regular and Advanced sections for improved navigation and accessibility
  * Site filtering settings now display dynamically with individual controls for granular permission management
  * Added Delete Synced Data option when device sync is enabled

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->