### PR TITLE
Implement Quick Pre-Check of Changed Roots Before Full Parse

### DIFF
--- a/services/domObserver.ts
+++ b/services/domObserver.ts
@@ -8,9 +8,42 @@ export class DOMObserver {
     this.textProcessor = textProcessor
   }
 
+  private hasAnyMatch(root: HTMLElement, quickCheck: RegExp): boolean {
+    const text = root.textContent
+    if (text) {
+      quickCheck.lastIndex = 0
+      if (quickCheck.test(text)) return true
+    }
+
+    for (const attr of TextProcessor.accessibilityAttributes) {
+      const selector = `[${attr}]`
+      const nodes = root.querySelectorAll(selector)
+      for (const el of nodes) {
+        const value = el.getAttribute(attr)
+        if (value) {
+          quickCheck.lastIndex = 0
+          if (quickCheck.test(value)) return true
+        }
+      }
+    }
+    return false
+  }
+
   setup(replacements: Map<RegExp, string>): void {
     // Clean up any existing observer
     this.disconnect()
+
+    const quickCheckSources: string[] = []
+    for (const pattern of replacements.keys()) {
+      // Strip Unicode word boundary lookaround for fast pre-check
+      const core = pattern.source
+        .replace(/^\(\?<!\\p\{L\}\)/, '')
+        .replace(/\(\?!\\p\{L\}\)$/, '')
+      quickCheckSources.push(core)
+    }
+    const quickCheck = quickCheckSources.length > 0
+      ? new RegExp(quickCheckSources.join('|'), 'iu')
+      : null
 
     const pendingRoots = new Set<HTMLElement>()
     let scheduled = false
@@ -53,7 +86,9 @@ export class DOMObserver {
           observerForThisFlush.disconnect()
           try {
             for (const root of deduped) {
-              void this.textProcessor.processSubtree(root, replacements, false)
+              if (!quickCheck || this.hasAnyMatch(root, quickCheck)) {
+                void this.textProcessor.processSubtree(root, replacements, false)
+              }
             }
           }
           finally {

--- a/services/domObserver.ts
+++ b/services/domObserver.ts
@@ -15,10 +15,12 @@ export class DOMObserver {
       if (quickCheck.test(text)) return true
     }
 
-    for (const attr of TextProcessor.accessibilityAttributes) {
-      const selector = `[${attr}]`
-      const nodes = root.querySelectorAll(selector)
-      for (const el of nodes) {
+    const selector = TextProcessor.accessibilityAttributes
+      .map(attr => `[${attr}]`)
+      .join(',')
+    const nodes = root.querySelectorAll(selector)
+    for (const el of nodes) {
+      for (const attr of TextProcessor.accessibilityAttributes) {
         const value = el.getAttribute(attr)
         if (value) {
           quickCheck.lastIndex = 0


### PR DESCRIPTION
- Before the Mutation Observer performs a full subtree replacement pass on a changed element, do a quick pass for substrings matching the pattern on the entire root's text content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced content processing efficiency to improve application performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->