### PR TITLE
Request Idle Callback Before Running Node Replacements

### DIFF
--- a/services/domObserver.ts
+++ b/services/domObserver.ts
@@ -1,5 +1,10 @@
 import { TextProcessor } from './textProcessor'
 
+const scheduleIdle: (cb: () => void) => void
+  = typeof requestIdleCallback === 'function'
+    ? cb => requestIdleCallback(cb, { timeout: 100 })
+    : cb => setTimeout(cb, 0)
+
 export class DOMObserver {
   private observer: MutationObserver | null = null
   private textProcessor: TextProcessor
@@ -70,7 +75,7 @@ export class DOMObserver {
           return
         }
         scheduled = true
-        void requestAnimationFrame(() => {
+        scheduleIdle(() => {
           if (this.observer !== observerForThisFlush) {
             pendingRoots.clear()
             scheduled = false


### PR DESCRIPTION
- Instead of requesting animation frame, request idle callback to schedule text replacements when rendering is not actively happening

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized DOM observer timing to improve performance efficiency by deferring root processing to idle periods instead of animation frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->