### PR TITLE
Resolve Parsing Status Incorrect Site After Settings Change

### DIFF
--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -1,12 +1,22 @@
 import { browser } from 'wxt/browser'
-import { defineBackground } from '#imports'
+import { defineBackground, storage } from '#imports'
 import { handleInstall, handleParsingStatusChange, handleUpdate } from './utils'
 import { getConfig, updateExtensionAppearance } from '@/services/configService'
 import { errorLog } from '@/utils'
+import { parsingStatusItem } from '@/services/siteFiltering'
 import type { Message, ParsingStatus } from '@/utils/types'
+
+const activeTabIdItem = storage.defineItem<number | null>('local:activeTabId', { defaultValue: null })
 
 export default defineBackground({
   main: () => {
+    // Tracks the currently active tab. Persisted so it survives service-worker restarts.
+    // sender.tab.id in onMessage does not require the `tabs` permission.
+    let currentActiveTabId: number | null = null
+    void activeTabIdItem.getValue().then((id) => {
+      currentActiveTabId = id
+    })
+
     // Check theming on extension load
     void (async () => {
       const config = await getConfig()
@@ -33,15 +43,28 @@ export default defineBackground({
     })
 
     // Handle messages from content scripts, popup, or options pages
-    browser.runtime.onMessage.addListener((message: Message, _sender) => {
+    browser.runtime.onMessage.addListener((message: Message, sender) => {
       switch (message.type) {
         case 'PARSING_STATUS_CHANGE':
           void handleParsingStatusChange(message.data as { status: ParsingStatus })
+          break
+        case 'CANDIDATE_PARSING_STATUS':
+          // Only the active tab's candidate is applied; background tabs are silently dropped.
+          if (sender.tab?.id === currentActiveTabId) {
+            void (async () => {
+              const { status } = message.data as { status: ParsingStatus }
+              await parsingStatusItem.setValue(status)
+              await handleParsingStatusChange({ status })
+            })()
+          }
+          break
       }
     })
 
     // Handle tab activation to recheck parsing status
     browser.tabs.onActivated.addListener((tab) => {
+      currentActiveTabId = tab.tabId
+      void activeTabIdItem.setValue(tab.tabId)
       void browser.tabs.sendMessage(tab.tabId, {
         type: 'RECHECK_PARSING_STATUS',
       }).catch((error: unknown) => {

--- a/entrypoints/background/index.ts
+++ b/entrypoints/background/index.ts
@@ -13,7 +13,7 @@ export default defineBackground({
     // Tracks the currently active tab. Persisted so it survives service-worker restarts.
     // sender.tab.id in onMessage does not require the `tabs` permission.
     let currentActiveTabId: number | null = null
-    void activeTabIdItem.getValue().then((id) => {
+    const activeTabIdReady = activeTabIdItem.getValue().then((id) => {
       currentActiveTabId = id
     })
 
@@ -49,14 +49,16 @@ export default defineBackground({
           void handleParsingStatusChange(message.data as { status: ParsingStatus })
           break
         case 'CANDIDATE_PARSING_STATUS':
-          // Only the active tab's candidate is applied; background tabs are silently dropped.
-          if (sender.tab?.id === currentActiveTabId) {
-            void (async () => {
-              const { status } = message.data as { status: ParsingStatus }
-              await parsingStatusItem.setValue(status)
-              await handleParsingStatusChange({ status })
-            })()
-          }
+          void activeTabIdReady.then(() => {
+            // Only the active tab's candidate is applied; background tabs are silently dropped.
+            if (sender.tab?.id === currentActiveTabId) {
+              void (async () => {
+                const { status } = message.data as { status: ParsingStatus }
+                await parsingStatusItem.setValue(status)
+                await handleParsingStatusChange({ status })
+              })()
+            }
+          })
           break
       }
     })

--- a/entrypoints/content/index.ts
+++ b/entrypoints/content/index.ts
@@ -39,21 +39,23 @@ function cleanupAndReset() {
   previousHighlight = undefined
 }
 
-async function configureAndRunProcessor({ config }: { config: UserSettings }): Promise<void> {
+async function configureAndRunProcessor({ config, updateStatus = true }: { config: UserSettings, updateStatus?: boolean }): Promise<void> {
   // Handle any transition to disabled state (either by extension disable or blocklist/allowlist)
   if (!config.enabled) {
     const wasEnabledBeforeCleanup = previousEnabled
     cleanupAndReset()
-    await siteFiltering.updateParsingStatus({
-      status: {
-        isParsing: false,
-        reason: 'extension_disabled',
-        allowMatch: null,
-        blockMatch: null,
-      },
-      hostname: window.location.hostname,
-      theme: config.theme,
-    })
+    if (updateStatus) {
+      await siteFiltering.updateParsingStatus({
+        status: {
+          isParsing: false,
+          reason: 'extension_disabled',
+          allowMatch: null,
+          blockMatch: null,
+        },
+        hostname: window.location.hostname,
+        theme: config.theme,
+      })
+    }
     if (wasEnabledBeforeCleanup) {
       await debugLog('extension disabled')
     }
@@ -65,9 +67,27 @@ async function configureAndRunProcessor({ config }: { config: UserSettings }): P
 
   if (!siteFilterResult.shouldParse) {
     cleanupAndReset()
+    if (updateStatus) {
+      await siteFiltering.updateParsingStatus({
+        status: {
+          isParsing: false,
+          reason: siteFilterResult.reason,
+          allowMatch: siteFilterResult.allowMatch,
+          blockMatch: siteFilterResult.blockMatch,
+        },
+        hostname: window.location.hostname,
+        theme: config.theme,
+      })
+    }
+    await debugLog(`not parsing site, reason: ${siteFilterResult.reason}, allowMatch: ${siteFilterResult.allowMatch ?? 'none'}, blockMatch: ${siteFilterResult.blockMatch ?? 'none'}`)
+    return
+  }
+
+  // If we reach here, parsing is enabled
+  if (updateStatus) {
     await siteFiltering.updateParsingStatus({
       status: {
-        isParsing: false,
+        isParsing: true,
         reason: siteFilterResult.reason,
         allowMatch: siteFilterResult.allowMatch,
         blockMatch: siteFilterResult.blockMatch,
@@ -75,21 +95,7 @@ async function configureAndRunProcessor({ config }: { config: UserSettings }): P
       hostname: window.location.hostname,
       theme: config.theme,
     })
-    await debugLog(`not parsing site, reason: ${siteFilterResult.reason}, allowMatch: ${siteFilterResult.allowMatch ?? 'none'}, blockMatch: ${siteFilterResult.blockMatch ?? 'none'}`)
-    return
   }
-
-  // If we reach here, parsing is enabled
-  await siteFiltering.updateParsingStatus({
-    status: {
-      isParsing: true,
-      reason: siteFilterResult.reason,
-      allowMatch: siteFilterResult.allowMatch,
-      blockMatch: siteFilterResult.blockMatch,
-    },
-    hostname: window.location.hostname,
-    theme: config.theme,
-  })
 
   // Check if names, theme, or highlightReplacedNames have changed
   const namesChanged = previousEnabled && haveNamesChanged(previousNames, config.names)
@@ -171,10 +177,12 @@ export default defineContentScript({
     await configureAndRunProcessor({ config })
     toggleKeybindingListener = await registerKeyboardShortcut({ config, listener: toggleKeybindingListener })
 
-    // Handle configuration changes
+    // Handle configuration changes — only update shared parsingStatus from the active tab to
+    // avoid a race where the last background tab to respond overwrites the active tab's site.
+    // Background tabs will update status when focused via the RECHECK_PARSING_STATUS message.
     setupConfigListener((config) => {
       void (async () => {
-        await configureAndRunProcessor({ config })
+        await configureAndRunProcessor({ config, updateStatus: document.visibilityState === 'visible' })
         toggleKeybindingListener = await registerKeyboardShortcut({ config, listener: toggleKeybindingListener })
       })()
     })

--- a/entrypoints/content/index.ts
+++ b/entrypoints/content/index.ts
@@ -2,7 +2,7 @@ import { defineContentScript } from '#imports'
 import { getConfig, setupConfigListener } from '@/services/configService'
 import { DOMObserver } from '@/services/domObserver'
 import { TextProcessor } from '@/services/textProcessor'
-import type { Names, UserSettings } from '@/utils/types'
+import type { Names, UserSettings, ParsingStatus, Message } from '@/utils/types'
 import {
   blockContent,
   unblockContent,
@@ -12,7 +12,6 @@ import {
 } from './utils'
 import { debugLog, haveNamesChanged, registerKeyboardShortcut } from '@/utils'
 import { SiteFiltering } from '@/services/siteFiltering'
-import type { Message } from '@/utils/types'
 
 let currentObserver: DOMObserver | null = null
 let previousEnabled: boolean | undefined = undefined
@@ -39,23 +38,51 @@ function cleanupAndReset() {
   previousHighlight = undefined
 }
 
-async function configureAndRunProcessor({ config, updateStatus = true }: { config: UserSettings, updateStatus?: boolean }): Promise<void> {
+// Writes parsingStatus either directly (initial load / recheck) or via a background-mediated
+// candidate message (config changes). The background only commits a candidate if the sending
+// tab is the currently active one, preventing background tabs from overwriting the status.
+async function publishParsingStatus(
+  args: {
+    status: Omit<ParsingStatus, 'site' | 'timestamp'>
+    hostname: string
+    theme: UserSettings['theme']
+  },
+  mode: 'direct' | 'candidate',
+): Promise<void> {
+  if (mode === 'direct') {
+    await siteFiltering.updateParsingStatus(args)
+    return
+  }
+  const newStatus: ParsingStatus = { ...args.status, site: args.hostname, timestamp: Date.now() }
+  await browser.runtime.sendMessage({
+    type: 'CANDIDATE_PARSING_STATUS',
+    data: { status: newStatus },
+  }).catch(() => {
+    // Service worker may be restarting; candidate dropped and recovered on next tab focus
+  })
+}
+
+async function configureAndRunProcessor({
+  config,
+  statusMode = 'direct',
+}: {
+  config: UserSettings
+  statusMode?: 'direct' | 'candidate'
+}): Promise<void> {
   // Handle any transition to disabled state (either by extension disable or blocklist/allowlist)
   if (!config.enabled) {
     const wasEnabledBeforeCleanup = previousEnabled
     cleanupAndReset()
-    if (updateStatus) {
-      await siteFiltering.updateParsingStatus({
-        status: {
-          isParsing: false,
-          reason: 'extension_disabled',
-          allowMatch: null,
-          blockMatch: null,
-        },
-        hostname: window.location.hostname,
-        theme: config.theme,
-      })
-    }
+    await publishParsingStatus({
+      status: {
+        isParsing: false,
+        reason: 'extension_disabled',
+        allowMatch: null,
+        blockMatch: null,
+      },
+      hostname: window.location.hostname,
+      theme: config.theme,
+    }, statusMode)
     if (wasEnabledBeforeCleanup) {
       await debugLog('extension disabled')
     }
@@ -67,35 +94,31 @@ async function configureAndRunProcessor({ config, updateStatus = true }: { confi
 
   if (!siteFilterResult.shouldParse) {
     cleanupAndReset()
-    if (updateStatus) {
-      await siteFiltering.updateParsingStatus({
-        status: {
-          isParsing: false,
-          reason: siteFilterResult.reason,
-          allowMatch: siteFilterResult.allowMatch,
-          blockMatch: siteFilterResult.blockMatch,
-        },
-        hostname: window.location.hostname,
-        theme: config.theme,
-      })
-    }
-    await debugLog(`not parsing site, reason: ${siteFilterResult.reason}, allowMatch: ${siteFilterResult.allowMatch ?? 'none'}, blockMatch: ${siteFilterResult.blockMatch ?? 'none'}`)
-    return
-  }
-
-  // If we reach here, parsing is enabled
-  if (updateStatus) {
-    await siteFiltering.updateParsingStatus({
+    await publishParsingStatus({
       status: {
-        isParsing: true,
+        isParsing: false,
         reason: siteFilterResult.reason,
         allowMatch: siteFilterResult.allowMatch,
         blockMatch: siteFilterResult.blockMatch,
       },
       hostname: window.location.hostname,
       theme: config.theme,
-    })
+    }, statusMode)
+    await debugLog(`not parsing site, reason: ${siteFilterResult.reason}, allowMatch: ${siteFilterResult.allowMatch ?? 'none'}, blockMatch: ${siteFilterResult.blockMatch ?? 'none'}`)
+    return
   }
+
+  // If we reach here, parsing is enabled
+  await publishParsingStatus({
+    status: {
+      isParsing: true,
+      reason: siteFilterResult.reason,
+      allowMatch: siteFilterResult.allowMatch,
+      blockMatch: siteFilterResult.blockMatch,
+    },
+    hostname: window.location.hostname,
+    theme: config.theme,
+  }, statusMode)
 
   // Check if names, theme, or highlightReplacedNames have changed
   const namesChanged = previousEnabled && haveNamesChanged(previousNames, config.names)
@@ -177,12 +200,9 @@ export default defineContentScript({
     await configureAndRunProcessor({ config })
     toggleKeybindingListener = await registerKeyboardShortcut({ config, listener: toggleKeybindingListener })
 
-    // Handle configuration changes — only update shared parsingStatus from the active tab to
-    // avoid a race where the last background tab to respond overwrites the active tab's site.
-    // Background tabs will update status when focused via the RECHECK_PARSING_STATUS message.
     setupConfigListener((config) => {
       void (async () => {
-        await configureAndRunProcessor({ config, updateStatus: document.visibilityState === 'visible' })
+        await configureAndRunProcessor({ config, statusMode: 'candidate' })
         toggleKeybindingListener = await registerKeyboardShortcut({ config, listener: toggleKeybindingListener })
       })()
     })


### PR DESCRIPTION
There was previously a race condition where the parsing status would be updated by all tabs when the settings changed. This PR resolves this by only updating the parsing status for the tab that is currently active.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented race conditions across multiple tabs by mediating parsing-status updates through the background process.
  * Ensured parsing status changes are applied only for the currently active tab, so background tabs no longer overwrite visible status.
  * Persisted active-tab tracking across background restarts for more consistent parsing-status behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/arimgibson/Deadname-Remover/pull/665?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->