### PR TITLE
Fix #672: Add characterData events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3.1
+
+- Fixed names not being replaced on sites that update text in place (e.g. Oracle Fusion/ADF); the mutation observer now also watches `characterData` changes
+
 ## v2.3.0
 
 - Fixed persistent performance issues with targeted improvements to text processing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Deadname Remover",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A browser extension that replaces deadnames with chosen names (primarily for transgender and non-binary people).",
   "private": true,
   "type": "module",

--- a/services/__tests__/domObserver.test.ts
+++ b/services/__tests__/domObserver.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi, afterAll } from 'vitest'
+import { DOMObserver } from '../domObserver'
+import { TextProcessor, createReplacementPattern } from '../textProcessor'
+
+// This project's test environment has no real DOM (see siteFiltering.test.ts,
+// which mocks `window` the same way), so we stand in minimal fakes for the
+// handful of DOM APIs domObserver.ts touches.
+class FakeMutationObserver {
+  static instances: FakeMutationObserver[] = []
+  lastObserveOptions: MutationObserverInit | undefined
+
+  constructor(public callback: MutationCallback) {
+    FakeMutationObserver.instances.push(this)
+  }
+
+  observe(_target: Node, options?: MutationObserverInit): void {
+    this.lastObserveOptions = options
+  }
+
+  disconnect(): void {
+    // no-op: nothing observes real DOM nodes in this fake
+  }
+}
+
+vi.stubGlobal('MutationObserver', FakeMutationObserver)
+vi.stubGlobal('document', { body: {} })
+
+afterAll(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('DOMObserver', () => {
+  it('observes characterData mutations, not just childList', () => {
+    FakeMutationObserver.instances = []
+    const observer = new DOMObserver(new TextProcessor())
+
+    observer.setup(new Map([[createReplacementPattern('Deadname'), 'Chosen']]))
+
+    const [instance] = FakeMutationObserver.instances
+    expect(instance.lastObserveOptions?.characterData).toBe(true)
+  })
+
+  it('reprocesses a mutated text node\'s parent (e.g. apps like Oracle Fusion/ADF that update text in place)', async () => {
+    FakeMutationObserver.instances = []
+    const textProcessor = new TextProcessor()
+    const processSubtree = vi.spyOn(textProcessor, 'processSubtree').mockReturnValue(undefined)
+
+    const observer = new DOMObserver(textProcessor)
+    const replacements = new Map([[createReplacementPattern('Deadname'), 'Chosen']])
+    observer.setup(replacements)
+
+    const fakeParent = {
+      textContent: 'Hello Deadname, welcome',
+      getAttribute: () => null,
+      querySelectorAll: () => [],
+    } as unknown as HTMLElement
+    const fakeTextNode = { parentElement: fakeParent } as unknown as Node
+
+    const [instance] = FakeMutationObserver.instances
+    instance.callback(
+      [{ type: 'characterData', target: fakeTextNode } as unknown as MutationRecord],
+      instance as unknown as MutationObserver,
+    )
+
+    // Processing is scheduled via requestIdleCallback, which falls back to
+    // setTimeout(cb, 0) outside a real browser.
+    await new Promise(resolve => setTimeout(resolve, 0))
+
+    expect(processSubtree).toHaveBeenCalledWith(fakeParent, replacements, false)
+  })
+})

--- a/services/__tests__/domObserver.test.ts
+++ b/services/__tests__/domObserver.test.ts
@@ -24,6 +24,7 @@ class FakeMutationObserver {
 
 vi.stubGlobal('MutationObserver', FakeMutationObserver)
 vi.stubGlobal('document', { body: {} })
+vi.stubGlobal('Node', { TEXT_NODE: 3 })
 
 afterAll(() => {
   vi.unstubAllGlobals()
@@ -54,7 +55,11 @@ describe('DOMObserver', () => {
       getAttribute: () => null,
       querySelectorAll: () => [],
     } as unknown as HTMLElement
-    const fakeTextNode = { parentElement: fakeParent } as unknown as Node
+    const fakeTextNode = {
+      nodeType: Node.TEXT_NODE,
+      nodeValue: 'Hello Deadname, welcome',
+      parentElement: fakeParent,
+    } as unknown as Node
 
     const [instance] = FakeMutationObserver.instances
     instance.callback(

--- a/services/__tests__/domObserver.test.ts
+++ b/services/__tests__/domObserver.test.ts
@@ -67,5 +67,9 @@ describe('DOMObserver', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(processSubtree).toHaveBeenCalledWith(fakeParent, replacements, false)
+
+    // The flush path disconnects and re-observes; make sure the
+    // re-observation still requests characterData mutations.
+    expect(instance.lastObserveOptions?.characterData).toBe(true)
   })
 })

--- a/services/domObserver.ts
+++ b/services/domObserver.ts
@@ -77,6 +77,12 @@ export class DOMObserver {
             }
           })
         }
+        else if (mutation.type === 'characterData') {
+          // For text changes, we still need to process the parent element
+          // to ensure we catch all related changes
+          const parent = mutation.target.parentElement
+          if (parent) pendingRoots.add(parent)
+        }
       }
       if (pendingRoots.size > 0 && !scheduled) {
         const observerForThisFlush = this.observer
@@ -111,6 +117,7 @@ export class DOMObserver {
             observerForThisFlush.observe(document.body, {
               childList: true,
               subtree: true,
+              characterData: true,
             })
           }
         })
@@ -120,6 +127,7 @@ export class DOMObserver {
     this.observer.observe(document.body, {
       childList: true,
       subtree: true,
+      characterData: true,
     })
   }
 

--- a/services/domObserver.ts
+++ b/services/domObserver.ts
@@ -5,6 +5,13 @@ const scheduleIdle: (cb: () => void) => void
     ? cb => requestIdleCallback(cb, { timeout: 100 })
     : cb => setTimeout(cb, 0)
 
+/** Shared so reconnect cannot drift from the initial observe() config */
+const OBSERVE_OPTIONS: MutationObserverInit = {
+  childList: true,
+  subtree: true,
+  characterData: true,
+}
+
 export class DOMObserver {
   private observer: MutationObserver | null = null
   private textProcessor: TextProcessor
@@ -13,20 +20,19 @@ export class DOMObserver {
     this.textProcessor = textProcessor
   }
 
+  private matchesQuickCheck(text: string, quickCheck: RegExp): boolean {
+    quickCheck.lastIndex = 0
+    return quickCheck.test(text)
+  }
+
   private hasAnyMatch(root: HTMLElement, quickCheck: RegExp): boolean {
     const text = root.textContent
-    if (text) {
-      quickCheck.lastIndex = 0
-      if (quickCheck.test(text)) return true
-    }
+    if (text && this.matchesQuickCheck(text, quickCheck)) return true
 
     // Check the root element itself (querySelectorAll only searches descendants)
     for (const attr of TextProcessor.accessibilityAttributes) {
       const value = root.getAttribute(attr)
-      if (value) {
-        quickCheck.lastIndex = 0
-        if (quickCheck.test(value)) return true
-      }
+      if (value && this.matchesQuickCheck(value, quickCheck)) return true
     }
 
     const selector = TextProcessor.accessibilityAttributes
@@ -36,13 +42,33 @@ export class DOMObserver {
     for (const el of nodes) {
       for (const attr of TextProcessor.accessibilityAttributes) {
         const value = el.getAttribute(attr)
-        if (value) {
-          quickCheck.lastIndex = 0
-          if (quickCheck.test(value)) return true
-        }
+        if (value && this.matchesQuickCheck(value, quickCheck)) return true
       }
     }
     return false
+  }
+
+  /**
+   * characterData updates are small but high volume, run quick check
+   * on content before adding overhead of enqueuing
+   */
+  private shouldEnqueueCharacterData(
+    mutation: MutationRecord,
+    quickCheck: RegExp | null,
+  ): HTMLElement | null {
+    if (!quickCheck) return null
+    if (mutation.target.nodeType !== Node.TEXT_NODE) return null
+
+    const textNode = mutation.target as Text
+    const parent = textNode.parentElement
+    if (!parent) return null
+
+    const value = textNode.nodeValue
+    if (!value) return null
+
+    if (!this.matchesQuickCheck(value, quickCheck)) return null
+
+    return parent
   }
 
   setup(replacements: Map<RegExp, string>): void {
@@ -78,9 +104,7 @@ export class DOMObserver {
           })
         }
         else if (mutation.type === 'characterData') {
-          // For text changes, we still need to process the parent element
-          // to ensure we catch all related changes
-          const parent = mutation.target.parentElement
+          const parent = this.shouldEnqueueCharacterData(mutation, quickCheck)
           if (parent) pendingRoots.add(parent)
         }
       }
@@ -114,21 +138,13 @@ export class DOMObserver {
             }
           }
           finally {
-            observerForThisFlush.observe(document.body, {
-              childList: true,
-              subtree: true,
-              characterData: true,
-            })
+            observerForThisFlush.observe(document.body, OBSERVE_OPTIONS)
           }
         })
       }
     })
 
-    this.observer.observe(document.body, {
-      childList: true,
-      subtree: true,
-      characterData: true,
-    })
+    this.observer.observe(document.body, OBSERVE_OPTIONS)
   }
 
   disconnect(): void {


### PR DESCRIPTION
Fixed names not being replaced on sites that update text in place (e.g. Oracle Fusion/ADF and other apps using partial-page rendering); the mutation observer now also watches `characterData` changes.

I could reproduce the before and after here: https://f.kiva.gay/2026/demo-characterdata.html

My testing:

- On Windows, Vivaldi and Edge
  - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36
  - Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36 Edg/150.0.0.0
- On Linux, Vivaldi and Firefox
  - Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/150.0.0.0 Safari/537.36
  - Mozilla/5.0 (X11; Linux x86_64; rv:152.0) Gecko/20100101 Firefox/152.0

AI disclosure: I used Claude Opus (and a little bit of accidental Fable) throughout, because I'm a backend dev and SRE. The last time I touched JS for a living was almost 20 years ago. I fully understand what the model did, but I don't really have the knowledge to do it myself.

I ran the same fix through two different agents (Claude Code and GH Copilot). When I asked them to add regression testing, each recommended adding a new different dependency to fully simulate the DOM, which I rejected. I'm not fully happy with the kind of testing I delivered instead, but it does test for that specific regression.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed name replacements not updating when websites change existing text in place.
  - Enhanced detection for text-content (character data) updates to ensure replacements are applied reliably.
- **Tests**
  - Added Vitest coverage for observing and processing in-place text updates.
- **Documentation**
  - Updated the changelog with a new **2.3.1** entry and released version **2.3.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->